### PR TITLE
prevent volley from caching requests

### DIFF
--- a/purchase/src/main/java/com/zarinpal/ewallets/purchase/HttpQueue.java
+++ b/purchase/src/main/java/com/zarinpal/ewallets/purchase/HttpQueue.java
@@ -25,6 +25,8 @@ class HttpQueue {
     }
 
     public void addToRequest(Request request) {
+        request.setShouldCache(false);
+        queue.getCache().clear();
         queue.add(request);
     }
 }


### PR DESCRIPTION
When a purchase is done. To perform a new purchase, the cached payment gateway url opens in the browser. As a result, a duplicate request error is displayed. So you have to avoid volley caching.